### PR TITLE
volunteer revamp: public page, home page redesign, shift detail add-v…

### DIFF
--- a/app/volunteer-tasks/page.tsx
+++ b/app/volunteer-tasks/page.tsx
@@ -13,6 +13,8 @@ import { VolunteerModifyStepOneIcon } from "@/components/icons/VolunteerModifySt
 import { VolunteerModifyStepTwoIcon } from "@/components/icons/VolunteerModifyStepTwoIcon";
 import { JourneyTheDogIcon } from "@/components/icons/JourneyTheDogIcon";
 import { ChevronDown, ChevronUp, X } from "lucide-react";
+import { WarehouseIcon } from "@phosphor-icons/react";
+import { PickupDeliveryIcon } from "@/components/icons/PickupDeliveryIcon";
 import { useAuth } from "@/contexts/AuthContext";
 import { TimeBlock } from "@/types/schedule";
 import { formatTime } from "@/lib/utils";
@@ -92,7 +94,7 @@ export default function VolunteerTasks() {
     return (
         <div className="h-full flex flex-col">
             {screen === "shiftlist" && (
-                <div className="flex flex-col gap-4 pt-4 flex-1 min-h-0 overflow-y-auto">
+                <div className="flex flex-col gap-4 md:gap-0 pt-4 flex-1 min-h-0 overflow-y-auto">
                     {userTimeBlocks.length === 0 && (
                         <div className="flex flex-1 flex-col items-center justify-center gap-9">
                             <div className="grayscale opacity-40"><JourneyTheDogIcon /></div>
@@ -110,8 +112,9 @@ export default function VolunteerTasks() {
                         const dateLabel = `${start.toLocaleDateString("en-US", { month: "short" }).toUpperCase()}, ${start.toLocaleDateString("en-US", { weekday: "short" }).toUpperCase()}`;
 
                         return (
-                            <div key={tb.id} className="w-full">
-                                <div className="pb-4">
+                            <div key={tb.id} className="w-full border-b border-gray-200">
+                                {/* mobile */}
+                                <div className="md:hidden pb-4">
                                     <div className="flex justify-between items-stretch">
                                         <div className="flex flex-col gap-2">
                                             <div className="flex items-center gap-3">
@@ -121,13 +124,17 @@ export default function VolunteerTasks() {
                                                 <p className="font-family-roboto font-semibold text-sm text-[#6B7A99]">{dateLabel}</p>
                                             </div>
                                             <div className="pl-10">
-                                                <p className="text-sm font-family-roboto">{tb.type === "Pickup/Delivery" ? "Pickups / Deliveries" : "Warehouse"}</p>
+                                                <p className="text-sm font-semibold text-text-1">{tb.name || <span className="italic text-gray-400">Unnamed Shift</span>}</p>
+                                                <div className="flex items-center gap-2 text-sm text-text-1">
+                                                    {tb.type === "Pickup/Delivery" ? <PickupDeliveryIcon /> : <WarehouseIcon className="w-4 h-4 shrink-0" />}
+                                                    {tb.type === "Pickup/Delivery" ? "Pickup/Delivery" : "Warehouse"}
+                                                </div>
                                                 <p className="text-sm font-family-roboto text-primary">Group: {userGroup?.name}</p>
                                             </div>
                                         </div>
                                         <div className="flex flex-col items-end justify-between">
                                             <div className="flex items-center gap-2 h-7">
-                                                <div className={`w-3 h-3 rounded-full ${tb.type === "Warehouse" ? "bg-yellow-400" : "bg-primary"}`} />
+                                                <div className={`w-3 h-3 rounded-full ${tb.type === "Warehouse" ? "bg-[#FBCF0B]" : "bg-primary"}`} />
                                                 <span className="text-sm">{timeRange}</span>
                                             </div>
                                             {isActive ? (
@@ -144,9 +151,46 @@ export default function VolunteerTasks() {
                                             )}
                                         </div>
                                     </div>
-
                                 </div>
-                                <div className="border-b border-gray-200" />
+
+                                {/* desktop */}
+                                <div className="hidden md:flex py-3 px-8 gap-5.5 items-center">
+                                    <div className="flex items-start gap-3 w-30 shrink-0">
+                                        <div className="w-9 h-9 rounded-full bg-primary text-white flex items-center justify-center font-semibold shrink-0">
+                                            {start.getDate()}
+                                        </div>
+                                        <div className="text-sm text-gray-500 font-medium mt-2">{dateLabel}</div>
+                                    </div>
+
+                                    <div className="flex items-center gap-2 shrink-0">
+                                        <div className={`w-3 h-3 rounded-full shrink-0 ${tb.type === "Warehouse" ? "bg-[#FBCF0B]" : "bg-primary"}`} />
+                                        <div className="w-27.5 text-sm text-text-1">{timeRange}</div>
+                                    </div>
+
+                                    <div className="ml-6 flex-1 min-w-16 text-sm font-semibold text-text-1 truncate">{tb.name || <span className="italic text-gray-400">Unnamed Shift</span>}</div>
+
+                                    <div className="ml-10 w-33.25 shrink-0 flex items-center gap-2 text-sm text-text-1">
+                                        {tb.type === "Pickup/Delivery" ? <PickupDeliveryIcon /> : <WarehouseIcon className="w-5 h-5 shrink-0" />}
+                                        {tb.type === "Pickup/Delivery" ? "Pickup/Delivery" : "Warehouse"}
+                                    </div>
+
+                                    <div className="ml-9 w-36 shrink-0 text-sm text-primary">{userGroup?.name}</div>
+
+                                    <div className="ml-auto shrink-0">
+                                        {isActive ? (
+                                            <button
+                                                onClick={() => { setSelectedShift(tb); setScreen("shiftoverview"); }}
+                                                className="bg-primary text-white w-24 h-8 rounded-sm text-sm"
+                                            >
+                                                Open
+                                            </button>
+                                        ) : (
+                                            <button className="border border-gray-300 text-primary w-24 h-8 rounded-sm text-sm">
+                                                Upcoming
+                                            </button>
+                                        )}
+                                    </div>
+                                </div>
                             </div>
                         );
                     })}

--- a/app/volunteer/layout.tsx
+++ b/app/volunteer/layout.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { usePageTitle } from "@/lib/usePageTitle";
+
+export default function VolunteerLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    usePageTitle("Volunteer – Journey Home");
+    return (
+        <div className="min-h-screen bg-white md:bg-[#D8E3E5] md:py-21.5">
+            <div className="md:max-w-270 md:mx-auto md:bg-white md:rounded-lg md:shadow-md">
+                {children}
+            </div>
+        </div>
+    );
+}

--- a/app/volunteer/page.tsx
+++ b/app/volunteer/page.tsx
@@ -1,17 +1,64 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { createPortal } from "react-dom";
 import { useTimeBlocks } from "@/lib/queries/timeblocks";
 import { DropdownMultiselect } from "@/components/inventory/DropdownMultiselect";
 import ShiftListView from "@/components/schedule/ShiftListView";
-import { ConfirmModal } from "@/components/general/ConfirmModal";
 import { useAuth } from "@/contexts/AuthContext";
+
+function SignInRequiredModal({ onLogin, onCreateAccount, onClose }: {
+    onLogin: () => void;
+    onCreateAccount: () => void;
+    onClose: () => void;
+}) {
+    useEffect(() => {
+        const prev = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+        document.addEventListener("keydown", onKey);
+        return () => { document.body.style.overflow = prev; document.removeEventListener("keydown", onKey); };
+    }, [onClose]);
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/25 font-family-roboto">
+            <div className="absolute inset-0" onClick={onClose} />
+            <div className="relative bg-white w-full max-w-md mx-4 px-8 py-7 flex flex-col rounded-xl shadow-lg">
+                <h1 className="text-xl font-semibold text-gray-900">Volunteer account required</h1>
+                <p className="text-sm text-[#8D8D8D] font-family-opensans mt-2">
+                    To sign up for a shift, you need to be logged in to a Journey Home volunteer account.
+                    If you don&apos;t have one yet, you can create one.
+                </p>
+                <div className="flex flex-col sm:flex-row gap-3 mt-8">
+                    <button
+                        onClick={onLogin}
+                        className="flex-1 h-10 bg-primary text-white text-sm font-medium rounded-sm hover:opacity-90 transition-opacity"
+                    >
+                        Log In
+                    </button>
+                    <button
+                        onClick={onCreateAccount}
+                        className="flex-1 h-10 border border-primary text-primary text-sm font-medium rounded-sm hover:bg-primary/5 transition-colors"
+                    >
+                        Create Account
+                    </button>
+                </div>
+                <button
+                    onClick={onClose}
+                    className="mt-4 text-sm text-gray-400 hover:text-gray-600 transition-colors self-center"
+                >
+                    Cancel
+                </button>
+            </div>
+        </div>
+    );
+}
 
 export default function VolunteerPage() {
     const router = useRouter();
     const { state: { currentUser, userData } } = useAuth();
-    const { allTB: timeBlocks = [] } = useTimeBlocks();
+    const { allTB: timeBlocks = [], isLoading } = useTimeBlocks();
 
     const [selectedTypes, setSelectedTypes] = useState<string[]>(["Warehouse", "Pickups / Deliveries"]);
     const [selectedAvailability, setSelectedAvailability] = useState<string[]>(["Available", "Full"]);
@@ -57,14 +104,18 @@ export default function VolunteerPage() {
                 <h1 className="text-xl font-medium md:text-2xl md:font-bold text-primary font-raleway">
                     Volunteering for JourneyHome
                 </h1>
-                <p className="text-sm font-bold text-text-1 mt-3">
-                    Be part of something that matters.
-                </p>
-                <p className="text-sm text-text-1 mt-1">
-                    Volunteering with Journey Home puts you at the center of the work — moving donations and getting essential items directly into the hands of families. It&apos;s hands-on, meaningful, and no experience is needed.
+                <p className="text-sm text-text-1 mt-3">
+                    Welcome to Journey Home's Sign Up System for our weekly Volunteer Pickups, Deliveries, and Organizing Days! We are ending homelessness, please join us and sign up to help! 
                 </p>
                 <p className="text-sm text-text-1 mt-3">
-                    <span className="font-semibold">Warehouse shifts</span> take place at our facility, where you&apos;ll help sort and organize donated goods to keep our shelves stocked.<br /><br /><span className="font-semibold">Pickup &amp; Delivery shifts</span> involve collecting donations from donors and bringing them to clients across the community.
+                    All Organizing Days are at our warehouse at 595 New Park Ave., West Hartford - NOTE this is a NEW address as of August 2024!
+                </p>
+                <p className="text-sm text-text-1 mt-3">
+                    Pick-up and delivery days typically also start at our warehouse on New Park Ave., but emails with the day's specific schedule will be sent out to all volunteers by the day before the event.  
+                </p>
+
+                <p className="text-sm text-text-1 mt-3">
+                    To ensure you receive the day's schedule, <span className="font-bold underline">please sign up at least 24 hours in advance of your volunteer shift.</span>
                 </p>
 
                 <div className="md:hidden mt-6 border-b border-gray-200" />
@@ -90,20 +141,26 @@ export default function VolunteerPage() {
             </div>
 
             <div className="w-full mt-5 pb-16 overflow-x-auto">
-                <ShiftListView
-                    timeBlocks={filteredTimeBlocks}
-                    currentUserID=""
-                    onSignUpClick={handleSignUpClick}
-                />
+                {isLoading ? (
+                    <div className="flex justify-center py-12">
+                        <div className="w-5 h-5 border-2 border-gray-200 border-t-primary rounded-full animate-spin" />
+                    </div>
+                ) : (
+                    <ShiftListView
+                        timeBlocks={filteredTimeBlocks}
+                        currentUserID=""
+                        onSignUpClick={handleSignUpClick}
+                    />
+                )}
             </div>
 
-            {showModal && (
-                <ConfirmModal
-                    title="Sign Up Required"
-                    message="To sign up for a shift, you'll need an account. Confirm to create one now."
-                    onConfirm={() => router.push("/signup")}
-                    onCancel={() => setShowModal(false)}
-                />
+            {showModal && createPortal(
+                <SignInRequiredModal
+                    onLogin={() => router.push("/login")}
+                    onCreateAccount={() => router.push("/signup")}
+                    onClose={() => setShowModal(false)}
+                />,
+                document.body
             )}
         </div>
     );

--- a/app/volunteer/page.tsx
+++ b/app/volunteer/page.tsx
@@ -13,6 +13,7 @@ function SignInRequiredModal({ onLogin, onCreateAccount, onClose }: {
     onCreateAccount: () => void;
     onClose: () => void;
 }) {
+
     useEffect(() => {
         const prev = document.body.style.overflow;
         document.body.style.overflow = "hidden";
@@ -105,17 +106,17 @@ export default function VolunteerPage() {
                     Volunteering for JourneyHome
                 </h1>
                 <p className="text-sm text-text-1 mt-3">
-                    Welcome to Journey Home's Sign Up System for our weekly Volunteer Pickups, Deliveries, and Organizing Days! We are ending homelessness, please join us and sign up to help! 
+                    Welcome to Journey Home&apos;s Sign Up System for our weekly Volunteer Pickups, Deliveries, and Organizing Days! We are ending homelessness, please join us and sign up to help!
                 </p>
                 <p className="text-sm text-text-1 mt-3">
                     All Organizing Days are at our warehouse at 595 New Park Ave., West Hartford - NOTE this is a NEW address as of August 2024!
                 </p>
                 <p className="text-sm text-text-1 mt-3">
-                    Pick-up and delivery days typically also start at our warehouse on New Park Ave., but emails with the day's specific schedule will be sent out to all volunteers by the day before the event.  
+                    Pick-up and delivery days typically also start at our warehouse on New Park Ave., but emails with the day&apos;s specific schedule will be sent out to all volunteers by the day before the event.
                 </p>
 
                 <p className="text-sm text-text-1 mt-3">
-                    To ensure you receive the day's schedule, <span className="font-bold underline">please sign up at least 24 hours in advance of your volunteer shift.</span>
+                    To ensure you receive the day&apos;s schedule, <span className="font-bold underline">please sign up at least 24 hours in advance of your volunteer shift.</span>
                 </p>
 
                 <div className="md:hidden mt-6 border-b border-gray-200" />
@@ -148,7 +149,7 @@ export default function VolunteerPage() {
                 ) : (
                     <ShiftListView
                         timeBlocks={filteredTimeBlocks}
-                        currentUserID=""
+                        currentUserID={userData?.uid ?? ""}
                         onSignUpClick={handleSignUpClick}
                     />
                 )}

--- a/app/volunteer/page.tsx
+++ b/app/volunteer/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTimeBlocks } from "@/lib/queries/timeblocks";
+import { DropdownMultiselect } from "@/components/inventory/DropdownMultiselect";
+import ShiftListView from "@/components/schedule/ShiftListView";
+import { ConfirmModal } from "@/components/general/ConfirmModal";
+import { useAuth } from "@/contexts/AuthContext";
+
+export default function VolunteerPage() {
+    const router = useRouter();
+    const { state: { currentUser, userData } } = useAuth();
+    const { allTB: timeBlocks = [] } = useTimeBlocks();
+
+    const [selectedTypes, setSelectedTypes] = useState<string[]>(["Warehouse", "Pickups / Deliveries"]);
+    const [selectedAvailability, setSelectedAvailability] = useState<string[]>(["Available", "Full"]);
+    const [showModal, setShowModal] = useState(false);
+
+    const handleSignUpClick = () => {
+        if (currentUser && userData?.role === "Volunteer") {
+            router.push("/volunteer-signup");
+        } else if (currentUser && userData?.role === "Admin") {
+            router.push("/schedule");
+        } else {
+            setShowModal(true);
+        }
+    };
+
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+
+    const filteredTimeBlocks = timeBlocks.filter((tb) => {
+        if (tb.startTime.toDate() < todayStart) return false;
+        if (!tb.published) return false;
+
+        const type = tb.type === "Pickup/Delivery" ? "Pickups / Deliveries" : "Warehouse";
+        const isAvailable = tb.volunteerGroups.some((g) => g.volunterIDs.length < g.maxNum);
+        const availability = isAvailable ? "Available" : "Full";
+
+        return selectedTypes.includes(type) && selectedAvailability.includes(availability);
+    });
+
+    return (
+        <div className="flex flex-col items-center md:pt-23.5">
+            <div className="md:hidden w-full px-4 py-4 flex items-center justify-center border-b border-gray-200">
+                <span className="font-family-raleway font-semibold text-[2rem] text-primary">Journey</span>
+                <span className="font-family-raleway font-semibold text-[2rem] text-secondary-1">Home</span>
+            </div>
+
+            <img
+                src="/journey-home-logo.png"
+                alt="Journey Home"
+                className="hidden md:block h-[6em] w-[22em]"
+            />
+
+            <div className="w-full mt-6 md:mt-12 px-6.25 md:px-13.75">
+                <h1 className="text-xl font-medium md:text-2xl md:font-bold text-primary font-raleway">
+                    Volunteering for JourneyHome
+                </h1>
+                <p className="text-sm font-bold text-text-1 mt-3">
+                    Be part of something that matters.
+                </p>
+                <p className="text-sm text-text-1 mt-1">
+                    Volunteering with Journey Home puts you at the center of the work — moving donations and getting essential items directly into the hands of families. It&apos;s hands-on, meaningful, and no experience is needed.
+                </p>
+                <p className="text-sm text-text-1 mt-3">
+                    <span className="font-semibold">Warehouse shifts</span> take place at our facility, where you&apos;ll help sort and organize donated goods to keep our shelves stocked.<br /><br /><span className="font-semibold">Pickup &amp; Delivery shifts</span> involve collecting donations from donors and bringing them to clients across the community.
+                </p>
+
+                <div className="md:hidden mt-6 border-b border-gray-200" />
+
+                <h2 className="text-xl font-medium md:text-2xl md:font-bold text-primary font-raleway mt-6 md:mt-12">
+                    Available Shifts
+                </h2>
+
+                <div className="flex flex-wrap gap-3 mt-4">
+                    <DropdownMultiselect
+                        label="Type"
+                        options={["Warehouse", "Pickups / Deliveries"]}
+                        selected={selectedTypes}
+                        setSelected={setSelectedTypes}
+                    />
+                    <DropdownMultiselect
+                        label="Availability"
+                        options={["Available", "Full"]}
+                        selected={selectedAvailability}
+                        setSelected={setSelectedAvailability}
+                    />
+                </div>
+            </div>
+
+            <div className="w-full mt-5 pb-16 overflow-x-auto">
+                <ShiftListView
+                    timeBlocks={filteredTimeBlocks}
+                    currentUserID=""
+                    onSignUpClick={handleSignUpClick}
+                />
+            </div>
+
+            {showModal && (
+                <ConfirmModal
+                    title="Sign Up Required"
+                    message="To sign up for a shift, you'll need an account. Confirm to create one now."
+                    onConfirm={() => router.push("/signup")}
+                    onCancel={() => setShowModal(false)}
+                />
+            )}
+        </div>
+    );
+}

--- a/app/volunteer/page.tsx
+++ b/app/volunteer/page.tsx
@@ -27,11 +27,10 @@ export default function VolunteerPage() {
         }
     };
 
-    const todayStart = new Date();
-    todayStart.setHours(0, 0, 0, 0);
+    const now = new Date();
 
     const filteredTimeBlocks = timeBlocks.filter((tb) => {
-        if (tb.startTime.toDate() < todayStart) return false;
+        if (tb.startTime.toDate() < now) return false;
         if (!tb.published) return false;
 
         const type = tb.type === "Pickup/Delivery" ? "Pickups / Deliveries" : "Warehouse";

--- a/components/general/StatusPage.tsx
+++ b/components/general/StatusPage.tsx
@@ -14,7 +14,7 @@ export function StatusPage({
 }) {
     return (
         <div className="w-full h-full flex items-center justify-center flex-col gap-4 bg-[#ECFBFE]">
-            <DogSitIcon />
+            <DogSitIcon className="text-[3em]"/>
             <h1 className="text-3xl text-text-2 pt-3">{title}</h1>
             <div className="flex items-center justify-center flex-col pt-3">
                 <p className="text-text-2">{message}</p>

--- a/components/homepage/ShiftTaskSummary.tsx
+++ b/components/homepage/ShiftTaskSummary.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { CaretRight as CaretRightIcon } from "@phosphor-icons/react";
+import { CaretRightIcon } from "@phosphor-icons/react";
 import { useTimeBlocks } from "@/lib/queries/timeblocks";
 import { useAuth } from "@/contexts/AuthContext";
 import { formatTime } from "@/lib/utils";
-import { TimeBlock } from "@/types/schedule";
 
 export default function ShiftTaskSummary() {
     const { allTB: timeblocks = [], isLoading } = useTimeBlocks();
@@ -13,193 +12,137 @@ export default function ShiftTaskSummary() {
     const userId = state.currentUser?.uid;
 
     const now = new Date();
-    const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const nowMs = now.getTime();
+    const todayMidnightMs = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+    const todayEndMs = todayMidnightMs + 86400000;
 
-    const myShifts = timeblocks
-        .filter((tb) => {
-            if (!userId) return false;
-            const startTime = tb.startTime.toDate();
-            const shiftDay = new Date(startTime.getFullYear(), startTime.getMonth(), startTime.getDate());
-            if (shiftDay < todayMidnight) return false;
-            return tb.volunteerGroups?.some((group) =>
-                group.volunterIDs?.includes(userId)
-            );
-        })
-        .sort((a, b) => a.startTime.toDate().getTime() - b.startTime.toDate().getTime())
-        .slice(0, 2);
+    const todayShifts = timeblocks.filter((tb) => {
+        if (!userId) return false;
+        const startMs = tb.startTime.toDate().getTime();
+        if (startMs < todayMidnightMs || startMs >= todayEndMs) return false;
+        return tb.volunteerGroups?.some((g) => g.volunterIDs?.includes(userId));
+    });
 
-    const groupedByDate = myShifts.reduce((acc, tb) => {
-        const dateKey = tb.startTime.toDate().toDateString();
-        if (!acc[dateKey]) acc[dateKey] = [];
-        acc[dateKey].push(tb);
-        return acc;
-    }, {} as Record<string, TimeBlock[]>);
+    const activeShift = todayShifts.find((tb) => {
+        const startMs = tb.startTime.toDate().getTime();
+        const endMs = tb.endTime?.toDate().getTime() ?? (startMs + 3600000);
+        return startMs <= nowMs && nowMs < endMs;
+    });
 
-    const sortedDateEntries = Object.entries(groupedByDate).sort(
-        ([a], [b]) => new Date(a).getTime() - new Date(b).getTime()
-    );
+    const selectedShift = activeShift ?? [...todayShifts].sort(
+        (a, b) => a.startTime.toDate().getTime() - b.startTime.toDate().getTime()
+    )[0];
+
+    if (isLoading) {
+        return (
+            <div className="h-24 flex items-center justify-center">
+                <div className="w-5 h-5 border-2 border-gray-200 border-t-primary rounded-full animate-spin" />
+            </div>
+        );
+    }
+
+    if (!selectedShift) return null;
+
+    const start = selectedShift.startTime.toDate();
+    const end = selectedShift.endTime?.toDate();
+    const startMs = start.getTime();
+    const endMs = end?.getTime() ?? (startMs + 3600000);
+    const isActive = startMs <= nowMs && nowMs < endMs;
+    const timeRange = end ? `${formatTime(start)}-${formatTime(end)}` : formatTime(start);
+    const date = start;
 
     return (
         <div>
             <Link href="/volunteer-tasks">
-                <div className="flex items-center mb-4 cursor-pointer gap-2">
-                    <h2 className="text-xl font-semibold text-gray-800 leading-none">
+                <div className="flex items-center mb-5 cursor-pointer gap-2">
+                    <h2 className="text-2xl font-semibold text-gray-800 leading-none">
                         Shift Tasks
                     </h2>
                     <CaretRightIcon className="w-5 h-5" />
                 </div>
             </Link>
 
-            <div className="border bg-white overflow-hidden">
-                {isLoading ? (
-                    <div className="h-64 flex items-center justify-center">
-                        <div className="w-5 h-5 border-2 border-gray-200 border-t-primary rounded-full animate-spin" />
-                    </div>
-                ) : myShifts.length === 0 ? (
-                    <div className="h-64 flex items-center justify-center text-sm text-gray-400">
-                        No shifts
-                    </div>
-                ) : (
-                    <>
-                        {/* mobile */}
-                        <div className="block md:hidden border-t border-gray-200">
-                            {sortedDateEntries.map(([dateKey, blocks]) => {
-                                const date = new Date(dateKey);
-                                return (
-                                    <div key={dateKey}>
-                                        <div className="px-4 space-y-3 pt-3 pb-3">
-                                            {blocks.map((tb, index) => {
-                                                const start = tb.startTime.toDate();
-                                                const end = tb.endTime?.toDate();
-                                                const shiftDayStart = new Date(start.getFullYear(), start.getMonth(), start.getDate()).getTime();
-                                                const isOngoing = shiftDayStart <= now.getTime() && now.getTime() < shiftDayStart + 86400000;
-                                                const timeRange = end
-                                                    ? `${formatTime(start)}-${formatTime(end)}`
-                                                    : formatTime(start);
-                                                const isFirst = index === 0;
-
-                                                const typeDot = (
-                                                    <div className={`w-3 h-3 rounded-full shrink-0 ${tb.type === "Warehouse" ? "bg-[#FBCF0B]" : "bg-primary"}`} />
-                                                );
-
-                                                const timeEl = (
-                                                    <div className="flex items-center gap-2 text-sm text-text-1 shrink-0">
-                                                        {typeDot}
-                                                        {timeRange}
-                                                    </div>
-                                                );
-
-                                                const button = isOngoing ? (
-                                                    <Link href={`/volunteer-tasks?id=${tb.id}`} className="text-sm h-8 w-24 flex items-center justify-center shrink-0 rounded-xs bg-primary text-white">
-                                                        Open
-                                                    </Link>
-                                                ) : (
-                                                    <div className="text-sm h-8 w-24 flex items-center justify-center shrink-0 rounded-xs bg-white text-primary border border-gray-300">
-                                                        Upcoming
-                                                    </div>
-                                                );
-
-                                                return (
-                                                    <div key={tb.id}>
-                                                        {isFirst && (
-                                                            <div className="flex items-center justify-between mb-2">
-                                                                <div className="flex items-center gap-3">
-                                                                    <div className="w-7 h-7 rounded-full bg-primary text-white text-sm flex items-center justify-center font-semibold shrink-0">
-                                                                        {date.getDate()}
-                                                                    </div>
-                                                                    <div className="text-sm font-medium text-gray-500">
-                                                                        {`${date.toLocaleDateString("en-US", { month: "short" }).toUpperCase()}, ${date.toLocaleDateString("en-US", { weekday: "short" }).toUpperCase()}`}
-                                                                    </div>
-                                                                </div>
-                                                                {timeEl}
-                                                            </div>
-                                                        )}
-                                                        <div className="flex items-start justify-between gap-4 pl-10">
-                                                            <div className="flex flex-col gap-1">
-                                                                <div className="text-sm text-text-1">{tb.name}</div>
-                                                                <div className="flex flex-col gap-1 text-sm text-primary">
-                                                                    {tb.volunteerGroups?.map((group) => (
-                                                                        <div key={group.name}>
-                                                                            {group.volunterIDs?.length ?? 0}/{group.maxNum ?? 0}{" "}
-                                                                            {group.name}
-                                                                        </div>
-                                                                    ))}
-                                                                </div>
-                                                            </div>
-                                                            <div className="flex flex-col items-end gap-1 shrink-0">
-                                                                {!isFirst && timeEl}
-                                                                {button}
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                );
-                                            })}
-                                        </div>
-                                        <div className="border-b border-gray-200 mx-4" />
-                                    </div>
-                                );
-                            })}
+            <div className="border bg-white overflow-hidden md:rounded">
+                {/* mobile */}
+                <div className="block md:hidden border-t border-gray-200">
+                    <div className="px-4 pt-3 pb-3">
+                        <div className="flex items-center justify-between mb-2">
+                            <div className="flex items-center gap-3">
+                                <div className="w-7 h-7 rounded-full bg-primary text-white text-sm flex items-center justify-center font-semibold shrink-0">
+                                    {date.getDate()}
+                                </div>
+                                <div className="text-sm font-medium text-gray-500">
+                                    {`${date.toLocaleDateString("en-US", { month: "short" }).toUpperCase()}, ${date.toLocaleDateString("en-US", { weekday: "short" }).toUpperCase()}`}
+                                </div>
+                            </div>
+                            <div className="flex items-center gap-2 text-sm text-text-1 shrink-0">
+                                <div className={`w-3 h-3 rounded-full shrink-0 ${selectedShift.type === "Warehouse" ? "bg-[#FBCF0B]" : "bg-primary"}`} />
+                                {timeRange}
+                            </div>
                         </div>
-
-                        {/* desktop */}
-                        <div className="hidden md:block w-full border-t border-gray-200">
-                            {sortedDateEntries.map(([dateKey, blocks]) => {
-                                const date = new Date(dateKey);
-                                return (
-                                    <div key={dateKey} className="border-b border-gray-200">
-                                        <div className="py-3 px-4 flex gap-4 items-start">
-                                            <div className="flex items-start gap-3 w-32">
-                                                <div className="w-8 h-8 rounded-full bg-primary text-white flex items-center justify-center font-semibold text-sm shrink-0">
-                                                    {date.getDate()}
-                                                </div>
-                                                <div className="text-sm text-gray-500 font-medium mt-1.5">
-                                                    {`${date.toLocaleDateString("en-US", { month: "short" }).toUpperCase()}, ${date.toLocaleDateString("en-US", { weekday: "short" }).toUpperCase()}`}
-                                                </div>
-                                            </div>
-                                            <div className="flex flex-col gap-3 flex-1">
-                                                {blocks.map((tb) => {
-                                                    const start = tb.startTime.toDate();
-                                                    const end = tb.endTime?.toDate();
-                                                    const shiftDayStart = new Date(start.getFullYear(), start.getMonth(), start.getDate()).getTime();
-                                                    const isOngoing = shiftDayStart <= now.getTime() && now.getTime() < shiftDayStart + 86400000;
-                                                    const timeRange = end
-                                                        ? `${formatTime(start)}-${formatTime(end)}`
-                                                        : formatTime(start);
-
-                                                    return (
-                                                        <div key={tb.id} className="flex items-center gap-4">
-                                                            <div className={`w-3 h-3 rounded-full shrink-0 ${tb.type === "Warehouse" ? "bg-[#FBCF0B]" : "bg-primary"}`} />
-                                                            <div className="w-24 shrink-0 text-sm text-text-1">{timeRange}</div>
-                                                            <div className="w-40 shrink-0 text-sm text-text-1">{tb.name}</div>
-                                                            <div className="flex flex-col gap-1 text-primary text-sm">
-                                                                {tb.volunteerGroups?.map((group) => (
-                                                                    <span key={group.name}>
-                                                                        {group.volunterIDs?.length ?? 0}/{group.maxNum ?? 0} {group.name}
-                                                                    </span>
-                                                                ))}
-                                                            </div>
-                                                            <div className="ml-auto shrink-0">
-                                                                {isOngoing ? (
-                                                                    <Link href={`/volunteer-tasks?id=${tb.id}`} className="text-sm h-8 w-24 flex items-center justify-center rounded-xs bg-primary text-white">
-                                                                        Open
-                                                                    </Link>
-                                                                ) : (
-                                                                    <div className="text-sm h-8 w-24 flex items-center justify-center rounded-xs bg-white text-primary border border-gray-300">
-                                                                        Upcoming
-                                                                    </div>
-                                                                )}
-                                                            </div>
-                                                        </div>
-                                                    );
-                                                })}
-                                            </div>
+                        <div className="flex items-start justify-between gap-4 pl-10">
+                            <div className="flex flex-col gap-1">
+                                <div className="text-sm text-text-1">{selectedShift.name}</div>
+                                <div className="flex flex-col gap-1 text-sm text-primary">
+                                    {selectedShift.volunteerGroups?.map((group) => (
+                                        <div key={group.name}>
+                                            {group.volunterIDs?.length ?? 0}/{group.maxNum ?? 0}{" "}
+                                            {group.name}
                                         </div>
+                                    ))}
+                                </div>
+                            </div>
+                            <div className="shrink-0">
+                                {isActive ? (
+                                    <Link href={`/volunteer-tasks?id=${selectedShift.id}`} className="text-sm h-8 w-24 flex items-center justify-center rounded-xs bg-primary text-white">
+                                        Open
+                                    </Link>
+                                ) : (
+                                    <div className="text-sm h-8 w-24 flex items-center justify-center rounded-xs bg-white text-primary border border-gray-300">
+                                        Upcoming
                                     </div>
-                                );
-                            })}
+                                )}
+                            </div>
                         </div>
-                    </>
-                )}
+                    </div>
+                </div>
+
+                {/* desktop */}
+                <div className="hidden md:block w-full border-t border-gray-200">
+                    <div className="border-b border-gray-200">
+                        <div className="py-3 px-4 flex gap-4 items-center">
+                            <div className="flex items-start gap-3 w-32 shrink-0">
+                                <div className="w-8 h-8 rounded-full bg-primary text-white flex items-center justify-center font-semibold text-sm shrink-0">
+                                    {date.getDate()}
+                                </div>
+                                <div className="text-sm text-gray-500 font-medium mt-1.5">
+                                    {`${date.toLocaleDateString("en-US", { month: "short" }).toUpperCase()}, ${date.toLocaleDateString("en-US", { weekday: "short" }).toUpperCase()}`}
+                                </div>
+                            </div>
+                            <div className={`w-3 h-3 rounded-full shrink-0 ${selectedShift.type === "Warehouse" ? "bg-[#FBCF0B]" : "bg-primary"}`} />
+                            <div className="w-24 shrink-0 text-sm text-text-1">{timeRange}</div>
+                            <div className="flex-1 min-w-0 text-sm font-semibold text-text-1 truncate">{selectedShift.name}</div>
+                            <div className="flex flex-col gap-1 text-primary text-sm shrink-0">
+                                {selectedShift.volunteerGroups?.map((group) => (
+                                    <span key={group.name}>
+                                        {group.volunterIDs?.length ?? 0}/{group.maxNum ?? 0} {group.name}
+                                    </span>
+                                ))}
+                            </div>
+                            <div className="ml-10 shrink-0">
+                                {isActive ? (
+                                    <Link href={`/volunteer-tasks?id=${selectedShift.id}`} className="text-sm h-8 w-24 flex items-center justify-center rounded-xs bg-primary text-white">
+                                        Open
+                                    </Link>
+                                ) : (
+                                    <div className="text-sm h-8 w-24 flex items-center justify-center rounded-xs bg-white text-primary border border-gray-300">
+                                        Upcoming
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/components/homepage/ShiftTaskSummary.tsx
+++ b/components/homepage/ShiftTaskSummary.tsx
@@ -29,9 +29,12 @@ export default function ShiftTaskSummary() {
         return startMs <= nowMs && nowMs < endMs;
     });
 
-    const selectedShift = activeShift ?? [...todayShifts].sort(
-        (a, b) => a.startTime.toDate().getTime() - b.startTime.toDate().getTime()
-    )[0];
+    const selectedShift = activeShift ?? [...todayShifts]
+        .filter((tb) => {
+            const endMs = tb.endTime?.toDate().getTime() ?? (tb.startTime.toDate().getTime() + 3600000);
+            return endMs > nowMs;
+        })
+        .sort((a, b) => a.startTime.toDate().getTime() - b.startTime.toDate().getTime())[0];
 
     if (isLoading) {
         return (

--- a/components/homepage/ShiftTaskSummary.tsx
+++ b/components/homepage/ShiftTaskSummary.tsx
@@ -5,6 +5,7 @@ import { CaretRightIcon } from "@phosphor-icons/react";
 import { useTimeBlocks } from "@/lib/queries/timeblocks";
 import { useAuth } from "@/contexts/AuthContext";
 import { formatTime } from "@/lib/utils";
+import { DogSitIcon } from "@/components/icons/DogSitIcon";
 
 export default function ShiftTaskSummary() {
     const { allTB: timeblocks = [], isLoading } = useTimeBlocks();
@@ -44,7 +45,21 @@ export default function ShiftTaskSummary() {
         );
     }
 
-    if (!selectedShift) return null;
+    if (!selectedShift) return (
+        <div>
+            <Link href="/volunteer-tasks">
+                <div className="flex items-center mb-5 cursor-pointer gap-2">
+                    <h2 className="text-2xl font-semibold text-gray-800 leading-none">Shift Tasks</h2>
+                    <CaretRightIcon className="w-5 h-5" />
+                </div>
+            </Link>
+            <div className="border bg-white overflow-hidden md:rounded flex flex-col items-center justify-center py-4 gap-2">
+                <DogSitIcon/>
+                
+                <p className="text-sm font-medium">No upcoming shifts!</p>
+            </div>
+        </div>
+    );
 
     const start = selectedShift.startTime.toDate();
     const end = selectedShift.endTime?.toDate();

--- a/components/homepage/VolunteerHomePage.tsx
+++ b/components/homepage/VolunteerHomePage.tsx
@@ -3,30 +3,49 @@
 import { ProtectedRoute } from "@/components/general/ProtectedRoute";
 import Navbar from "@/components/general/Navbar";
 import ShiftTaskSummary from "./ShiftTaskSummary";
-import AvailableShiftsSummary from "./AvailableShiftsSummary";
 import { useAuth } from "@/contexts/AuthContext";
+import Link from "next/link";
 
 export default function VolunteerHomePage() {
     const { state } = useAuth();
     const user = state.userData;
 
-    const name = user?.firstName ||"Volunteer";
+    const name = user?.firstName || "Volunteer";
 
     return (
         <ProtectedRoute allow={["Volunteer"]}>
             <div className="h-full w-full flex flex-col font-family-roboto">
                 <div className="flex flex-1 min-h-0 max-md:flex-col">
                     <Navbar />
-                    <div className="flex-1 overflow-y-auto bg-white pt-8 max-md:pt-4 pb-4 px-6 flex flex-col gap-6 border-l border-light-border">
-                        <span className="text-4xl font-semibold text-primary leading-none block">
+                    <div className="flex-1 overflow-y-auto bg-linear-to-r from-[#F8FDFE] to-[#DAF2F5] pt-14 max-md:pt-4 pb-4 px-14 max-md:px-6 flex flex-col gap-6 border-l border-light-border">
+                        <span className="text-5xl font-semibold text-primary leading-none block">
                             Welcome, {name}!
                         </span>
 
                         {/* shift tasks */}
-                        <ShiftTaskSummary />
+                        <div className="mt-3 md:border md:border-light-border md:rounded-[0.625rem] md:pt-6 md:pr-4 md:pb-5 md:pl-5 md:shadow-sm md:overflow-hidden md:bg-white">
+                            <ShiftTaskSummary />
+                        </div>
 
-                        {/* available shifts */}
-                        <AvailableShiftsSummary />
+                        {/* volunteer blurb */}
+                        <div className="mt-3 md:border md:border-light-border md:rounded-[0.625rem] md:pt-6 md:pr-4 md:pb-7 md:pl-5 md:shadow-sm md:overflow-hidden md:bg-white">
+                            <h2 className="text-2xl font-semibold text-black leading-none">Volunteering for JourneyHome</h2>
+                            <p className="text-sm font-bold text-text-1 mt-5">Be part of something that matters.</p>
+                            <p className="text-sm text-text-1 mt-1">
+                                Volunteering with Journey Home puts you at the center of the work — moving donations and getting essential items directly into the hands of families. It&apos;s hands-on, meaningful, and no experience is needed.
+                            </p>
+                            <p className="text-sm text-text-1 mt-3">
+                                <span className="font-semibold">Warehouse shifts</span> take place at our facility, where you&apos;ll help sort and organize donated goods to keep our shelves stocked.<br /><br />
+                                <span className="font-semibold">Pickup &amp; Delivery shifts</span> involve collecting donations from donors and bringing them to clients across the community.
+                            </p>
+                            <Link
+                                href="/volunteer-signup"
+                                className="mt-5 w-full md:w-85 h-8 bg-primary text-white text-sm font-family-roboto rounded-sm flex items-center justify-center"
+                            >
+                                Sign Up to Volunteer
+                            </Link>
+                        </div>
+
                     </div>
                 </div>
             </div>

--- a/components/homepage/VolunteerHomePage.tsx
+++ b/components/homepage/VolunteerHomePage.tsx
@@ -17,7 +17,7 @@ export default function VolunteerHomePage() {
             <div className="h-full w-full flex flex-col font-family-roboto">
                 <div className="flex flex-1 min-h-0 max-md:flex-col">
                     <Navbar />
-                    <div className="flex-1 overflow-y-auto bg-linear-to-r from-[#F8FDFE] to-[#DAF2F5] pt-14 max-md:pt-4 pb-4 px-14 max-md:px-6 flex flex-col gap-6 border-l border-light-border">
+                    <div className="flex-1 overflow-y-auto bg-linear-to-r from-[#F8FDFE] to-[#EDF7F8] pt-14 max-md:pt-4 pb-4 px-14 max-md:px-6 flex flex-col gap-6 border-l border-light-border">
                         <span className="text-5xl font-semibold text-primary leading-none block">
                             Welcome, {name}!
                         </span>
@@ -29,7 +29,7 @@ export default function VolunteerHomePage() {
 
                         {/* volunteer blurb */}
                         <div className="mt-3 md:border md:border-light-border md:rounded-[0.625rem] md:pt-6 md:pr-4 md:pb-7 md:pl-5 md:shadow-sm md:overflow-hidden md:bg-white">
-                            <h2 className="text-2xl font-semibold text-black leading-none">Volunteering for JourneyHome</h2>
+                            <h2 className="text-2xl font-semibold text-black leading-none">Volunteering for Journey Home</h2>
                             <p className="text-sm font-bold text-text-1 mt-5">Be part of something that matters.</p>
                             <p className="text-sm text-text-1 mt-1">
                                 Volunteering with Journey Home puts you at the center of the work — moving donations and getting essential items directly into the hands of families. It&apos;s hands-on, meaningful, and no experience is needed.

--- a/components/icons/DogSitIcon.tsx
+++ b/components/icons/DogSitIcon.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-export function DogSitIcon() {
+export function DogSitIcon({ className }: { className?: string }) {
     return (
         <svg
-            width="185"
-            height="210"
+            width="4em"
+            height="4em"
             viewBox="0 0 185 210"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
+            className={className}
         >
             <path
                 d="M146.82 94.6699C157.44 88.9099 161.95 80.4599 163.16 77.5399C165.58 71.7099 165.35 64.9599 162.11 59.2599C161.98 59.0399 161.85 58.8099 161.72 58.5899C154.13 45.9199 157.59 6.56992 126.29 11.2299C94.9905 15.8899 66.5105 23.2599 79.8705 49.5399C92.8905 75.1399 53.2404 86.6099 118.53 99.1599C126.57 100.7 138.22 99.2599 146.82 94.6699Z"

--- a/components/inventory/SearchBox.tsx
+++ b/components/inventory/SearchBox.tsx
@@ -4,34 +4,33 @@ type SearchBoxProps = {
     value: string;
     onChange: React.Dispatch<React.SetStateAction<string>>;
     onSubmit: () => void;
+    inputClassName?: string;
 };
 
-export function SearchBox({ value, onChange, onSubmit }: SearchBoxProps) {
+export function SearchBox({ value, onChange, onSubmit, inputClassName = "w-60" }: SearchBoxProps) {
     return (
-        <>
-            <div className="h-8 border border-light-border rounded-xs flex shrink-0">
-                <form
-                    className="flex"
-                    onSubmit={(e) => {
-                        e.preventDefault();
-                        onSubmit();
-                    }}
+        <div className="h-8 border border-light-border rounded-xs flex shrink-0">
+            <form
+                className="flex"
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    onSubmit();
+                }}
+            >
+                <input
+                    type="text"
+                    className={`${inputClassName} h-8 text-sm text-text-1 placeholder:text-[#BFBFBF] px-3 outline-none`}
+                    placeholder="Search"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+                <button
+                    type="submit"
+                    className="h-8 w-8 border-l border-light-border flex items-center justify-center"
                 >
-                    <input
-                        type="text"
-                        className="w-60 h-8 text-sm text-text-1 placeholder:text-[#BFBFBF] px-3 outline-none"
-                        placeholder="Search"
-                        value={value}
-                        onChange={(e) => onChange(e.target.value)}
-                    />
-                    <button
-                        type="submit"
-                        className="h-8 w-8 border-l border-light-border flex items-center justify-center"
-                    >
-                        <SearchIcon />
-                    </button>
-                </form>
-            </div>
-        </>
+                    <SearchIcon />
+                </button>
+            </form>
+        </div>
     );
 }

--- a/components/schedule/ShiftDetailOverlay.tsx
+++ b/components/schedule/ShiftDetailOverlay.tsx
@@ -7,12 +7,14 @@ import {
   TrashIcon,
   XIcon,
   XCircleIcon,
+  PlusCircleIcon,
   UserIcon,
   MapPinIcon,
   CubeIcon,
   SteeringWheelIcon,
   UsersThreeIcon,
 } from "@phosphor-icons/react";
+import { SearchBox } from "../inventory/SearchBox";
 import { TimeBlock, Task } from "../../types/schedule";
 import { DonationRequest } from "../../types/donations";
 import { ClientRequest } from "../../types/client-requests";
@@ -59,6 +61,9 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
     groupName: string;
     name: string;
   } | null>(null);
+  const [addVolunteerGroup, setAddVolunteerGroup] = useState<string | null>(null);
+  const [volunteerSearch, setVolunteerSearch] = useState("");
+  const [selectedVolunteerUids, setSelectedVolunteerUids] = useState<string[]>([]);
 
   // Always derive from live cache so optimistic updates (toggle, volunteer removal) reflect immediately
   const liveTimeBlock = timeBlock
@@ -69,6 +74,9 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
     setShowEdit(false);
     setConfirmDelete(false);
     setRemoveTarget(null);
+    setAddVolunteerGroup(null);
+    setVolunteerSearch("");
+    setSelectedVolunteerUids([]);
   }, [timeBlock]);
 
   useEffect(() => {
@@ -79,11 +87,13 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !confirmDelete && !removeTarget) onClose();
+      if (e.key !== "Escape") return;
+      if (addVolunteerGroup) { setAddVolunteerGroup(null); setVolunteerSearch(""); setSelectedVolunteerUids([]); }
+      else if (!confirmDelete && !removeTarget) onClose();
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [onClose, confirmDelete, removeTarget]);
+  }, [onClose, confirmDelete, removeTarget, addVolunteerGroup]);
 
   if (!liveTimeBlock) return null;
 
@@ -100,6 +110,22 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
   const startDate = liveTimeBlock.startTime.toDate();
   const endDate = liveTimeBlock.endTime.toDate();
   const isPickupType = liveTimeBlock.type === "Pickup/Delivery";
+
+  const currentGroup = addVolunteerGroup
+    ? (liveTimeBlock.volunteerGroups.find(g => g.name === addVolunteerGroup) ?? null)
+    : null;
+  const remainingSpots = currentGroup
+    ? currentGroup.maxNum - currentGroup.volunterIDs.length - selectedVolunteerUids.length
+    : 0;
+  const allAssignedUids = new Set(liveTimeBlock.volunteerGroups.flatMap(g => g.volunterIDs));
+  const volunteerSearchResults = volunteerSearch && currentGroup && remainingSpots > 0
+    ? allAccounts.filter(u =>
+        u.role === "Volunteer" &&
+        !allAssignedUids.has(u.uid) &&
+        !selectedVolunteerUids.includes(u.uid) &&
+        `${u.firstName} ${u.lastName}`.toLowerCase().includes(volunteerSearch.toLowerCase())
+      )
+    : null;
 
   const handleTogglePublished = async (checked: boolean) => {
     await setTimeblockToast({ ...liveTimeBlock, published: checked });
@@ -121,17 +147,30 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
     setRemoveTarget(null);
   };
 
+  const handleAddVolunteer = async () => {
+    if (!selectedVolunteerUids.length || !addVolunteerGroup) return;
+    const updatedGroups = liveTimeBlock.volunteerGroups.map(g =>
+      g.name === addVolunteerGroup
+        ? { ...g, volunterIDs: [...g.volunterIDs, ...selectedVolunteerUids.filter(uid => !g.volunterIDs.includes(uid))] }
+        : g
+    );
+    await setTimeblockToast({ ...liveTimeBlock, volunteerGroups: updatedGroups });
+    setAddVolunteerGroup(null);
+    setVolunteerSearch("");
+    setSelectedVolunteerUids([]);
+  };
+
   return createPortal(
     <>
       <div
         className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
         onClick={onClose}
       >
-        <div
-          ref={overlayRef}
-          className="w-[25em] h-[37.5em] rounded-[0.625em] bg-[#FBFCFD] shadow-2xl flex flex-col px-6 py-4.5 overflow-hidden"
-          onClick={e => e.stopPropagation()}
-        >
+        <div className="flex items-start gap-4" onClick={e => e.stopPropagation()}>
+          <div
+            ref={overlayRef}
+            className="w-[25em] h-[37.5em] rounded-[0.625em] bg-[#FBFCFD] shadow-2xl flex flex-col px-6 py-4.5 overflow-hidden"
+          >
           {/* Icon row */}
           <div className="flex justify-end gap-3 shrink-0">
             <button
@@ -197,7 +236,7 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
 
               {/* Volunteer groups */}
               {liveTimeBlock.volunteerGroups.length === 0 ? (
-                <p className="text-sm text-gray-400 italic">No volunteer groups</p>
+                <p className="text-sm text-gray-400">No volunteer groups</p>
               ) : (
                 <div className="space-y-4">
                   {liveTimeBlock.volunteerGroups.map(group => {
@@ -212,31 +251,36 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
                           <GroupIcon className="w-4 h-4 shrink-0" />
                           {group.name}&nbsp;|&nbsp;{group.volunterIDs.length}/{group.maxNum}
                         </p>
-                        {groupVolunteers.length === 0 ? (
-                          <p className="text-xs text-gray-400 italic mt-2">No one signed up</p>
-                        ) : (
-                          <div className="flex flex-wrap gap-2 mt-2">
-                            {groupVolunteers.map(v => (
-                              <span
-                                key={v.uid}
-                                className="inline-flex items-center gap-1 py-1 px-2.5 rounded-xs bg-[#D4F0ED] text-[#003530] text-sm"
+                        <div className="flex flex-wrap gap-2 mt-2">
+                          {groupVolunteers.map(v => (
+                            <span
+                              key={v.uid}
+                              className="inline-flex items-center gap-1 py-1 px-2.5 rounded-xs bg-[#D4F0ED] text-[#003530] text-sm"
+                            >
+                              {v.firstName} {v.lastName}
+                              <button
+                                onClick={() => setRemoveTarget({
+                                  userId: v.uid,
+                                  groupName: group.name,
+                                  name: `${v.firstName} ${v.lastName}`,
+                                })}
+                                className="flex items-center"
+                                aria-label={`Remove ${v.firstName} ${v.lastName}`}
                               >
-                                {v.firstName} {v.lastName}
-                                <button
-                                  onClick={() => setRemoveTarget({
-                                    userId: v.uid,
-                                    groupName: group.name,
-                                    name: `${v.firstName} ${v.lastName}`,
-                                  })}
-                                  className="flex items-center"
-                                  aria-label={`Remove ${v.firstName} ${v.lastName}`}
-                                >
-                                  <XCircleIcon className="h-[1em] w-[1em]" />
-                                </button>
-                              </span>
-                            ))}
-                          </div>
-                        )}
+                                <XCircleIcon className="h-[1em] w-[1em]" />
+                              </button>
+                            </span>
+                          ))}
+                          {group.volunterIDs.length < group.maxNum && (
+                            <button
+                              onClick={() => { setAddVolunteerGroup(group.name); setVolunteerSearch(""); setSelectedVolunteerUids([]); }}
+                              className="inline-flex items-center gap-1 py-1 px-2.5 rounded-xs bg-gray-100 text-black text-sm hover:opacity-70 transition-opacity"
+                            >
+                              Add volunteer
+                              <PlusCircleIcon className="h-[1em] w-[1em]" />
+                            </button>
+                          )}
+                        </div>
                       </div>
                     );
                   })}
@@ -252,7 +296,7 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
                 <p className="text-sm font-medium text-[#565656]">Shift Details</p>
 
                 {liveTimeBlock.tasks.length === 0 ? (
-                  <p className="text-sm text-gray-400 italic mt-3">No tasks assigned</p>
+                  <p className="text-sm italic text-gray-400 mt-3">No tasks assigned</p>
                 ) : (
                   <div className="space-y-4 mt-3">
                     {liveTimeBlock.tasks.map((task, idx) => {
@@ -334,6 +378,73 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
 
             </div>
           </div>
+          </div>
+
+          {/* Volunteer selection panel — appears to the right of the shift card */}
+          {addVolunteerGroup && (
+            <div className="w-56 shrink-0 bg-[#FBFCFD] rounded-[0.625em] shadow-2xl flex flex-col overflow-hidden">
+              {/* Header */}
+              <div className="px-6 py-4 shrink-0 flex items-center justify-between">
+                <h2 className="text-xl font-medium font-family-roboto text-[#565656]">Select volunteers</h2>
+                <button onClick={() => { setAddVolunteerGroup(null); setVolunteerSearch(""); setSelectedVolunteerUids([]); }} className="text-slate-400 hover:opacity-60 transition-opacity">
+                  <XIcon className="w-3.5 h-3.5" />
+                </button>
+              </div>
+              {/* Body */}
+              <div className="px-6 pb-4">
+                <SearchBox value={volunteerSearch} onChange={setVolunteerSearch} onSubmit={() => {}} inputClassName="w-36" />
+                {volunteerSearch && (
+                  remainingSpots <= 0 ? (
+                    <p className="mt-2 text-xs text-gray-400 px-1">Group is full</p>
+                  ) : volunteerSearchResults && volunteerSearchResults.length > 0 ? (
+                    <div className="mt-2 border border-light-border rounded-xs max-h-36 overflow-y-auto">
+                      {volunteerSearchResults.map(u => (
+                        <button
+                          key={u.uid}
+                          onClick={() => setSelectedVolunteerUids(prev => [...prev, u.uid])}
+                          className="w-full text-left px-3 py-1.5 text-sm text-text-1 hover:bg-gray-50 transition-colors"
+                        >
+                          {u.firstName} {u.lastName}
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="mt-2 text-xs text-gray-400 px-1">No volunteers found</p>
+                  )
+                )}
+                {selectedVolunteerUids.length > 0 && (
+                  <div className="flex flex-wrap gap-2 mt-2">
+                    {selectedVolunteerUids.map(uid => {
+                      const u = allAccounts.find(a => a.uid === uid);
+                      return (
+                        <span key={uid} className="inline-flex items-center gap-1 py-1 px-2.5 rounded-xs bg-[#D4F0ED] text-[#003530] text-sm">
+                          <span className="max-w-28 truncate">{u ? `${u.firstName} ${u.lastName}` : uid}</span>
+                          <button
+                            onClick={() => setSelectedVolunteerUids(prev => prev.filter(id => id !== uid))}
+                            className="flex items-center"
+                            aria-label={`Deselect ${u ? `${u.firstName} ${u.lastName}` : uid}`}
+                          >
+                            <XCircleIcon className="h-[1em] w-[1em]" />
+                          </button>
+                        </span>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+              {/* Footer */}
+              <div className="flex justify-end px-6 py-4 shrink-0">
+                <button
+                  onClick={handleAddVolunteer}
+                  disabled={!selectedVolunteerUids.length}
+                  className="h-8 px-6 bg-primary text-white text-sm rounded-sm hover:opacity-90 transition-opacity disabled:opacity-40"
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+          )}
+
         </div>
       </div>
 

--- a/components/schedule/ShiftDetailOverlay.tsx
+++ b/components/schedule/ShiftDetailOverlay.tsx
@@ -44,6 +44,97 @@ function formatAddress(addr: { streetAddress: string; apt: string; city: string;
   return `${addr.streetAddress}${aptSuffix}, ${addr.city}, ${addr.state} ${addr.zipCode}`;
 }
 
+interface VolunteerSelectPanelProps {
+  groupName: string;
+  remainingSpots: number;
+  allAccounts: ReturnType<typeof useAllActiveAccounts>["allAccounts"];
+  assignedUids: string[];
+  onClose: () => void;
+  onSave: (uids: string[]) => void;
+}
+
+function VolunteerSelectPanel({ groupName, remainingSpots, allAccounts, assignedUids, onClose, onSave }: VolunteerSelectPanelProps) {
+  const [search, setSearch] = useState("");
+  const [selectedUids, setSelectedUids] = useState<string[]>([]);
+
+  const spotsLeft = remainingSpots - selectedUids.length;
+  const assignedSet = new Set(assignedUids);
+
+  const searchResults = search && spotsLeft > 0
+    ? allAccounts.filter(u =>
+        u.role === "Volunteer" &&
+        !assignedSet.has(u.uid) &&
+        !selectedUids.includes(u.uid) &&
+        (
+          `${u.firstName} ${u.lastName}`.toLowerCase().includes(search.toLowerCase()) ||
+          u.email?.toLowerCase().includes(search.toLowerCase())
+        )
+      )
+    : null;
+
+  return (
+    <div className="w-80 shrink-0 bg-[#FBFCFD] rounded-[0.625em] shadow-2xl flex flex-col overflow-hidden">
+      <div className="px-6 py-4 shrink-0 flex items-center justify-between border-b border-[#E3E3E3]">
+        <h2 className="text-base font-medium font-family-roboto text-[#565656]">Add to {groupName}</h2>
+        <button onClick={onClose} className="text-slate-400 hover:opacity-60 transition-opacity">
+          <XIcon className="w-3.5 h-3.5" />
+        </button>
+      </div>
+      <div className="px-6 py-4 flex-1 overflow-y-auto space-y-3">
+        <SearchBox value={search} onChange={setSearch} onSubmit={() => {}}/>
+        {search && (
+          spotsLeft <= 0 ? (
+            <p className="text-xs text-gray-400">Group is full</p>
+          ) : searchResults && searchResults.length > 0 ? (
+            <div className="border border-light-border rounded-xs max-h-40 overflow-y-auto">
+              {searchResults.map(u => (
+                <button
+                  key={u.uid}
+                  onClick={() => setSelectedUids(prev => [...prev, u.uid])}
+                  className="w-full text-left px-3 py-2 hover:bg-gray-50 transition-colors"
+                >
+                  <div className="text-sm text-text-1">{u.firstName} {u.lastName}</div>
+                  <div className="text-xs text-gray-400">{u.email}</div>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-gray-400">No volunteers found</p>
+          )
+        )}
+        {selectedUids.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {selectedUids.map(uid => {
+              const u = allAccounts.find(a => a.uid === uid);
+              return (
+                <span key={uid} className="inline-flex items-center gap-1 py-1 px-2.5 rounded-xs bg-[#D4F0ED] text-[#003530] text-sm">
+                  <span className="max-w-32 truncate">{u ? `${u.firstName} ${u.lastName}` : uid}</span>
+                  <button
+                    onClick={() => setSelectedUids(prev => prev.filter(id => id !== uid))}
+                    className="flex items-center"
+                    aria-label={`Deselect ${u ? `${u.firstName} ${u.lastName}` : uid}`}
+                  >
+                    <XCircleIcon className="h-[1em] w-[1em]" />
+                  </button>
+                </span>
+              );
+            })}
+          </div>
+        )}
+      </div>
+      <div className="flex justify-end px-6 py-4 shrink-0 border-t border-[#E3E3E3]">
+        <button
+          onClick={() => onSave(selectedUids)}
+          disabled={!selectedUids.length}
+          className="h-8 px-6 bg-primary text-white text-sm rounded-sm hover:opacity-90 transition-opacity disabled:opacity-40"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}
+
 interface Props {
   timeBlock: TimeBlock | null;
   onClose: () => void;
@@ -62,8 +153,6 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
     name: string;
   } | null>(null);
   const [addVolunteerGroup, setAddVolunteerGroup] = useState<string | null>(null);
-  const [volunteerSearch, setVolunteerSearch] = useState("");
-  const [selectedVolunteerUids, setSelectedVolunteerUids] = useState<string[]>([]);
 
   // Always derive from live cache so optimistic updates (toggle, volunteer removal) reflect immediately
   const liveTimeBlock = timeBlock
@@ -75,8 +164,6 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
     setConfirmDelete(false);
     setRemoveTarget(null);
     setAddVolunteerGroup(null);
-    setVolunteerSearch("");
-    setSelectedVolunteerUids([]);
   }, [timeBlock]);
 
   useEffect(() => {
@@ -88,7 +175,7 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
-      if (addVolunteerGroup) { setAddVolunteerGroup(null); setVolunteerSearch(""); setSelectedVolunteerUids([]); }
+      if (addVolunteerGroup) { setAddVolunteerGroup(null); }
       else if (!confirmDelete && !removeTarget) onClose();
     };
     document.addEventListener("keydown", handleKeyDown);
@@ -111,20 +198,8 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
   const endDate = liveTimeBlock.endTime.toDate();
   const isPickupType = liveTimeBlock.type === "Pickup/Delivery";
 
-  const currentGroup = addVolunteerGroup
+  const addVolunteerGroupData = addVolunteerGroup
     ? (liveTimeBlock.volunteerGroups.find(g => g.name === addVolunteerGroup) ?? null)
-    : null;
-  const remainingSpots = currentGroup
-    ? currentGroup.maxNum - currentGroup.volunterIDs.length - selectedVolunteerUids.length
-    : 0;
-  const allAssignedUids = new Set(liveTimeBlock.volunteerGroups.flatMap(g => g.volunterIDs));
-  const volunteerSearchResults = volunteerSearch && currentGroup && remainingSpots > 0
-    ? allAccounts.filter(u =>
-        u.role === "Volunteer" &&
-        !allAssignedUids.has(u.uid) &&
-        !selectedVolunteerUids.includes(u.uid) &&
-        `${u.firstName} ${u.lastName}`.toLowerCase().includes(volunteerSearch.toLowerCase())
-      )
     : null;
 
   const handleTogglePublished = async (checked: boolean) => {
@@ -147,17 +222,15 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
     setRemoveTarget(null);
   };
 
-  const handleAddVolunteer = async () => {
-    if (!selectedVolunteerUids.length || !addVolunteerGroup) return;
+  const handleAddVolunteer = async (uids: string[]) => {
+    if (!uids.length || !addVolunteerGroup) return;
     const updatedGroups = liveTimeBlock.volunteerGroups.map(g =>
       g.name === addVolunteerGroup
-        ? { ...g, volunterIDs: [...g.volunterIDs, ...selectedVolunteerUids.filter(uid => !g.volunterIDs.includes(uid))] }
+        ? { ...g, volunterIDs: [...g.volunterIDs, ...uids.filter(uid => !g.volunterIDs.includes(uid))] }
         : g
     );
     await setTimeblockToast({ ...liveTimeBlock, volunteerGroups: updatedGroups });
     setAddVolunteerGroup(null);
-    setVolunteerSearch("");
-    setSelectedVolunteerUids([]);
   };
 
   return createPortal(
@@ -231,7 +304,7 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
           <div className="mt-4 h-px bg-[#E3E3E3] shrink-0" />
 
           {/* Scrollable body */}
-          <div className="flex-1 overflow-y-auto">
+          <div className="flex-1 overflow-y-auto overflow-x-hidden">
             <div className="pt-4 pb-1">
 
               {/* Volunteer groups */}
@@ -273,8 +346,8 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
                           ))}
                           {group.volunterIDs.length < group.maxNum && (
                             <button
-                              onClick={() => { setAddVolunteerGroup(group.name); setVolunteerSearch(""); setSelectedVolunteerUids([]); }}
-                              className="inline-flex items-center gap-1 py-1 px-2.5 rounded-xs bg-gray-100 text-black text-sm hover:opacity-70 transition-opacity"
+                              onClick={() => setAddVolunteerGroup(group.name)}
+                              className="inline-flex items-center gap-1 py-1 px-2.5 rounded-xs bg-[#E3E3E3] text-black text-sm hover:opacity-70 transition-opacity"
                             >
                               Add volunteer
                               <PlusCircleIcon className="h-[1em] w-[1em]" />
@@ -381,68 +454,15 @@ export function ShiftDetailOverlay({ timeBlock, onClose }: Props) {
           </div>
 
           {/* Volunteer selection panel — appears to the right of the shift card */}
-          {addVolunteerGroup && (
-            <div className="w-56 shrink-0 bg-[#FBFCFD] rounded-[0.625em] shadow-2xl flex flex-col overflow-hidden">
-              {/* Header */}
-              <div className="px-6 py-4 shrink-0 flex items-center justify-between">
-                <h2 className="text-xl font-medium font-family-roboto text-[#565656]">Select volunteers</h2>
-                <button onClick={() => { setAddVolunteerGroup(null); setVolunteerSearch(""); setSelectedVolunteerUids([]); }} className="text-slate-400 hover:opacity-60 transition-opacity">
-                  <XIcon className="w-3.5 h-3.5" />
-                </button>
-              </div>
-              {/* Body */}
-              <div className="px-6 pb-4">
-                <SearchBox value={volunteerSearch} onChange={setVolunteerSearch} onSubmit={() => {}} inputClassName="w-36" />
-                {volunteerSearch && (
-                  remainingSpots <= 0 ? (
-                    <p className="mt-2 text-xs text-gray-400 px-1">Group is full</p>
-                  ) : volunteerSearchResults && volunteerSearchResults.length > 0 ? (
-                    <div className="mt-2 border border-light-border rounded-xs max-h-36 overflow-y-auto">
-                      {volunteerSearchResults.map(u => (
-                        <button
-                          key={u.uid}
-                          onClick={() => setSelectedVolunteerUids(prev => [...prev, u.uid])}
-                          className="w-full text-left px-3 py-1.5 text-sm text-text-1 hover:bg-gray-50 transition-colors"
-                        >
-                          {u.firstName} {u.lastName}
-                        </button>
-                      ))}
-                    </div>
-                  ) : (
-                    <p className="mt-2 text-xs text-gray-400 px-1">No volunteers found</p>
-                  )
-                )}
-                {selectedVolunteerUids.length > 0 && (
-                  <div className="flex flex-wrap gap-2 mt-2">
-                    {selectedVolunteerUids.map(uid => {
-                      const u = allAccounts.find(a => a.uid === uid);
-                      return (
-                        <span key={uid} className="inline-flex items-center gap-1 py-1 px-2.5 rounded-xs bg-[#D4F0ED] text-[#003530] text-sm">
-                          <span className="max-w-28 truncate">{u ? `${u.firstName} ${u.lastName}` : uid}</span>
-                          <button
-                            onClick={() => setSelectedVolunteerUids(prev => prev.filter(id => id !== uid))}
-                            className="flex items-center"
-                            aria-label={`Deselect ${u ? `${u.firstName} ${u.lastName}` : uid}`}
-                          >
-                            <XCircleIcon className="h-[1em] w-[1em]" />
-                          </button>
-                        </span>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-              {/* Footer */}
-              <div className="flex justify-end px-6 py-4 shrink-0">
-                <button
-                  onClick={handleAddVolunteer}
-                  disabled={!selectedVolunteerUids.length}
-                  className="h-8 px-6 bg-primary text-white text-sm rounded-sm hover:opacity-90 transition-opacity disabled:opacity-40"
-                >
-                  Save
-                </button>
-              </div>
-            </div>
+          {addVolunteerGroup && addVolunteerGroupData && (
+            <VolunteerSelectPanel
+              groupName={addVolunteerGroup}
+              remainingSpots={addVolunteerGroupData.maxNum - addVolunteerGroupData.volunterIDs.length}
+              allAccounts={allAccounts}
+              assignedUids={liveTimeBlock.volunteerGroups.flatMap(g => g.volunterIDs)}
+              onClose={() => setAddVolunteerGroup(null)}
+              onSave={handleAddVolunteer}
+            />
           )}
 
         </div>

--- a/components/schedule/ShiftListView.tsx
+++ b/components/schedule/ShiftListView.tsx
@@ -7,14 +7,17 @@ import { ConfirmModal } from "@/components/general/ConfirmModal";
 import Button from "@/components/form/Button";
 import { useTimeBlocks } from "@/lib/queries/timeblocks";
 import { Check } from "lucide-react";
+import { WarehouseIcon } from "@phosphor-icons/react";
+import { PickupDeliveryIcon } from "@/components/icons/PickupDeliveryIcon";
 import ShiftSignUpConfirm from "@/components/schedule/ShiftSignUpConfirm";
 
 type Props = {
     timeBlocks: TimeBlock[];
     currentUserID: string;
+    onSignUpClick?: () => void;
 };
 
-export default function ShiftListView({ timeBlocks, currentUserID }: Props) {
+export default function ShiftListView({ timeBlocks, currentUserID, onSignUpClick }: Props) {
     const [selectedTB, setSelectedTB] = useState<TimeBlock | null>(null);
     const [action, setAction] = useState<"signup" | "drop" | null>(null);
     const { setTimeblockToast, signUpToast } = useTimeBlocks();
@@ -92,6 +95,10 @@ export default function ShiftListView({ timeBlocks, currentUserID }: Props) {
                                         />
                                     );
 
+                                    const typeIcon = type === "Pickup/Delivery"
+                                        ? <PickupDeliveryIcon />
+                                        : <WarehouseIcon className="w-4 h-4 shrink-0" />;
+
                                     const timeEl = (
                                         <div className="flex items-center gap-2 text-sm text-text-1 shrink-0">
                                             {typeDot}
@@ -114,6 +121,7 @@ export default function ShiftListView({ timeBlocks, currentUserID }: Props) {
                                         <Button
                                             className="text-sm w-22 h-8 py-0 flex items-center justify-center shrink-0 rounded-xs"
                                             onClick={() => {
+                                                if (onSignUpClick) { onSignUpClick(); return; }
                                                 setSelectedTB(tb);
                                                 setAction("signup");
                                                 setSelectedGroup(null);
@@ -139,9 +147,13 @@ export default function ShiftListView({ timeBlocks, currentUserID }: Props) {
                                                 </div>
                                             )}
 
-                                            <div className="flex items-start justify-between gap-4 pl-[2.5rem]">
-                                                <div className="flex flex-col gap-1">
-                                                    <div className="text-sm text-text-1">{tb.name}</div>
+                                            <div className="flex items-start justify-between gap-4 pl-10">
+                                                <div className="flex flex-col gap-1 flex-1 min-w-0">
+                                                    <div className="text-sm font-semibold text-text-1">{tb.name || <span className="italic text-gray-400">Unnamed Shift</span>}</div>
+                                                    <div className="flex items-center gap-2 text-sm text-text-1">
+                                                        {typeIcon}
+                                                        {type === "Pickup/Delivery" ? "Pickup/Delivery" : "Warehouse"}
+                                                    </div>
                                                     <div className="flex flex-col gap-1 text-sm text-primary">
                                                         {tb.volunteerGroups.map((group) => (
                                                             <div key={group.name}>
@@ -182,13 +194,13 @@ export default function ShiftListView({ timeBlocks, currentUserID }: Props) {
 
                     return (
                         <div key={dateKey} className="border-b border-gray-200">
-                            <div className="py-3 px-8 flex gap-6 items-start">
-                            <div className="flex items-start gap-4 w-40">
-                                <div className="w-10 h-10 rounded-full bg-primary text-white flex items-center justify-center font-semibold">
+                            <div className="py-3 px-8 flex gap-5.5 items-start">
+                            <div className="flex items-start gap-3 w-30">
+                                <div className="w-9 h-9 rounded-full bg-primary text-white flex items-center justify-center font-semibold">
                                     {date.getDate()}
                                 </div>
 
-                                <div className="text-sm text-gray-500 font-medium mt-2.5">
+                                <div className="text-sm text-gray-500 font-medium mt-2">
                                     {`${date.toLocaleDateString("en-US", {
                                         month: "short",
                                     }).toUpperCase()}, ${date
@@ -215,27 +227,39 @@ export default function ShiftListView({ timeBlocks, currentUserID }: Props) {
                                     const type = tb.type;
 
                                     return (
-                                        <div
-                                            key={tb.id}
-                                            className="flex items-center gap-4"
-                                        >
-                                            <div
-                                                className={`w-3 h-3 rounded-full shrink-0 ${
-                                                    type === "Warehouse"
-                                                        ? "bg-[#FBCF0B]"
-                                                        : "bg-primary"
-                                                }`}
-                                            />
-
-                                            <div className="w-28 shrink-0 text-sm text-text-1">
-                                                {timeRange}
+                                        <div key={tb.id} className="flex items-center">
+                                            <div className="flex items-center gap-2 shrink-0">
+                                                <div
+                                                    className={`w-3 h-3 rounded-full shrink-0 ${
+                                                        type === "Warehouse"
+                                                            ? "bg-[#FBCF0B]"
+                                                            : "bg-primary"
+                                                    }`}
+                                                />
+                                                <div className="w-27.5 text-sm text-text-1">
+                                                    {timeRange}
+                                                </div>
                                             </div>
 
-                                            <div className="w-64 shrink-0 text-sm text-text-1">
-                                                {tb.name}
+                                            <div className="ml-6 flex-1 min-w-16 text-sm font-semibold text-text-1 truncate">
+                                                {tb.name || <span className="italic text-gray-400">Unnamed Shift</span>}
                                             </div>
 
-                                            <div className="flex flex-col gap-1 text-primary text-sm">
+                                            <div className="ml-10 w-33.25 shrink-0 flex items-center gap-2 text-sm text-text-1">
+                                                {type === "Pickup/Delivery" ? (
+                                                    <>
+                                                        <PickupDeliveryIcon />
+                                                        Pickup/Delivery
+                                                    </>
+                                                ) : (
+                                                    <>
+                                                        <WarehouseIcon className="w-5 h-5 shrink-0" />
+                                                        Warehouse
+                                                    </>
+                                                )}
+                                            </div>
+
+                                            <div className="ml-9 shrink-0 flex flex-col gap-1 text-primary text-sm">
                                                 {tb.volunteerGroups.map((group) => (
                                                     <span key={group.name}>
                                                         {group.volunterIDs.length}/{group.maxNum} {group.name}
@@ -243,7 +267,7 @@ export default function ShiftListView({ timeBlocks, currentUserID }: Props) {
                                                 ))}
                                             </div>
 
-                                            <div className="ml-auto flex items-center gap-3 shrink-0">
+                                            <div className="ml-10 flex items-center gap-3 shrink-0">
                                                 {isSignedUp && (
                                                     <span className="flex items-center gap-1 text-sm text-primary">
                                                         <Check className="w-4 h-4" />
@@ -254,7 +278,7 @@ export default function ShiftListView({ timeBlocks, currentUserID }: Props) {
                                                 {isSignedUp ? (
                                                     <Button
                                                         variant="secondary"
-                                                        className="text-sm font-roboto h-8 py-0 px-4 rounded-xs flex items-center"
+                                                        className="text-sm font-roboto h-8 py-0 w-24 rounded-xs flex items-center justify-center"
                                                         onClick={() => {
                                                             setSelectedTB(tb);
                                                             setAction("drop");
@@ -264,8 +288,9 @@ export default function ShiftListView({ timeBlocks, currentUserID }: Props) {
                                                     </Button>
                                                 ) : (
                                                     <Button
-                                                        className="text-sm font-roboto h-8 py-0 px-4 rounded-xs flex items-center"
+                                                        className="text-sm font-roboto h-8 py-0 w-24 rounded-xs flex items-center justify-center"
                                                         onClick={() => {
+                                                            if (onSignUpClick) { onSignUpClick(); return; }
                                                             setSelectedTB(tb);
                                                             setAction("signup");
                                                             setSelectedGroup(null);


### PR DESCRIPTION
Still needs: Logo on home page bottom 

General:

- Add public /volunteer page with auth-aware sign-up routing
- Rewrite VolunteerHomePage with gradient bg, card layout, blurb section
- Rewrite ShiftTaskSummary to show only today's active/soonest shift
- Add volunteer selection panel to ShiftDetailOverlay (beside modal, multi-select, capacity enforcement)
- Add SearchBox inputClassName prop for flexible input sizing
- Add desktop layout to volunteer-tasks shift list with fixed column widths
- Add "Unnamed Shift" fallback in ShiftListView and volunteer-tasks
- Fix mobile time alignment in ShiftListView

Details:
  ---
  New files
  - app/volunteer/layout.tsx — public volunteer page layout
  (min-h-screen, white on mobile, gray card on desktop)
  - app/volunteer/page.tsx — public volunteer landing page with
  shift type descriptions, auth-aware sign-up button (Volunteer →
  /volunteer-signup, Admin → /schedule, else → modal → /signup),
  real copy, overflow-x-auto for narrow widths

  ---
  Modified files

  components/homepage/VolunteerHomePage.tsx
  - Replaced AvailableShiftsSummary with a volunteer blurb section
   and "Sign Up to Volunteer" CTA
  - Added "Volunteering for JourneyHome" heading (24px)
  - Gradient background matching admin home page
  - Shift tasks wrapped in a white card (border,
  rounded-[0.625rem], shadow) on desktop with specific padding
  - Blurb section in its own matching card with heading, copy, and
   340px button inside
  - Welcome text bumped to text-5xl (48px)
  - Desktop padding px-14 pt-14

  components/homepage/ShiftTaskSummary.tsx
  - Complete rewrite: now shows only today's active shift, or the
  soonest upcoming shift today; returns null if no shifts today
  - "Shift Tasks" heading bumped to text-2xl (24px)
  - mb-5 between heading and shift row
  - md:rounded on the inner border div

  components/inventory/SearchBox.tsx
  - Added optional inputClassName prop (defaults to "w-60") so
  callers can control input width 
  
  components/schedule/ShiftDetailOverlay.tsx
  - Added "Add volunteer" gray chip per group (hidden when group
  is full)
  - Volunteer selection panel appears beside the shift card (flex
  siblings, not an overlay)
  - Panel: fixed w-56, SearchBox with w-36 input, multi-select
  teal chips with truncation, Save button
  - Derived currentGroup, remainingSpots, allAssignedUids,
  volunteerSearchResults consts (replaces IIFE)
  - Volunteers already in any group on the shift are excluded from
   search
  - ESC closes panel first, then overlay
  - "No tasks assigned" and "No notes" remain italic; "Group is
  full" / "No volunteers found" are not italic
  - Tailwind canonical classes fixed (w-56, max-w-28)
  - aria-label on chip deselect buttons
  - Indentation fixes on the portal structure

  components/schedule/ShiftListView.tsx
  - Desktop title column: flex-1 min-w-16 to prevent collapse at
  narrow widths
  - Desktop button container: ml-10 fixed gap to volunteer groups
  - "Unnamed Shift" italic fallback on both mobile and desktop
  when tb.name is empty
  
  app/volunteer-tasks/page.tsx
  - Added full desktop row layout (was mobile-only before): date
  circle, dot+time, name, type icon, group name (w-36 fixed),
  Open/Upcoming button
  - border-b between rows, md:gap-0
  - "Unnamed Shift" italic fallback on both mobile and desktop
  - Fixed group name column width (w-36) to prevent button
  shifting between Lead Drivers and General Volunteers rows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated volunteer page with type + availability filters and streamlined signup flow
  * Add volunteers to shift groups directly from the shift details panel
  * New volunteer page layout wrapper for consistent styling

* **Improvements**
  * Updated shift list UI with clearer icons and distinct mobile/desktop layouts
  * Homepage now surfaces only today’s shift and adds a volunteer blurb with CTA
  * Search box accepts customizable input sizing for reuse across the app

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hack4Impact-UMD/journey-home/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->